### PR TITLE
Fix wrong URLs 4 metaStore

### DIFF
--- a/js/metastore-utils.js
+++ b/js/metastore-utils.js
@@ -85,7 +85,7 @@ export function readSchemaIds(){
                 result =  output;
             },
             error: function (result) {
-                let message = "Failed to read schema ids from URL " + config.ajaxBaseUrl + "/schemas/" + ". (HTTP " + result.status + ")";
+                let message = "Failed to read schema ids from URL " + config.ajaxBaseUrl + "/schemas" + ". (HTTP " + result.status + ")";
                 result = message;
             }
         });

--- a/js/metastore-utils.js
+++ b/js/metastore-utils.js
@@ -72,7 +72,7 @@ export function readSchemaIds(){
         let result = undefined;
         $.ajax({
             type: "GET",
-            url: config.ajaxBaseUrl + "schemas/?size=100",
+            url: config.ajaxBaseUrl + "schemas?size=100",
             contentType: "application/json",
             dataType: 'json',
             async: false,
@@ -248,7 +248,7 @@ export function createMetadataRecord(valueMetadataRecord, metadataDocumentFile) 
     return new Promise(function (resolve, reject) {
         $.ajax({
             type: "POST",
-            url: config.ajaxBaseUrl + "metadata/",
+            url: config.ajaxBaseUrl + "metadata",
             contentType: false,
             processData: false,
             data: formData,

--- a/js/metastore-utils.js
+++ b/js/metastore-utils.js
@@ -288,7 +288,7 @@ export function createSchemaRecord(valueSchemaRecord, schemaDocumentFile) {
     return new Promise(function (resolve, reject) {
         $.ajax({
             type: "POST",
-            url: config.ajaxBaseUrl + "schemas/",
+            url: config.ajaxBaseUrl + "schemas",
             contentType: false,
             processData: false,
             data: formData,

--- a/metadata-management.html
+++ b/metadata-management.html
@@ -355,7 +355,7 @@
         let selectedMetadataId = null;
 
         currentAjaxBaseUrl = ajaxBaseUrl;
-        ajaxURL = currentAjaxBaseUrl + "ui/metadata/";
+        ajaxURL = currentAjaxBaseUrl + "ui/metadata";
         config.ajaxBaseUrl = currentAjaxBaseUrl;
         $('#metastore-base-url').val(currentAjaxBaseUrl);
         tableDefinitionMetadata.ajaxURL = ajaxURL;


### PR DESCRIPTION
Due to the MetaStore upgrade to SpringBoot 3, endpoints with a trailing '/' are no longer accepted.
This implementation works with both the old and new versions.