### PR TITLE
Fix Mapping Service Settings handling

### DIFF
--- a/mapping-service-ui.html
+++ b/mapping-service-ui.html
@@ -49,16 +49,16 @@
             <div class="fourteen wide column">
                 <div class="ui fluid icon input">
                     <input id="endpoint" type="text" placeholder="http://localhost:8095/" value="http://localhost:8095/">
-                    <button class="ui vertical animated button" tabindex="0" onclick="setUrl()">
+                    <button class="ui vertical animated button" tabindex="0" onclick="setUrl(document.getElementById('endpoint').value)">
                         <div class="hidden content">Reload</div>
                         <div class="visible content">
                             <i class="fa-solid fa-arrows-rotate"></i>
                         </div>
                     </button>
                     <script>
-                        function setUrl() {
-                            let url = document.getElementById("endpoint").value;
+                        function setUrl(url) {
                             document.getElementById("input-component").setAttribute("base-url", url);
+                            document.getElementById("endpoint").setAttribute("value", url);
                         }
                     </script>
                 </div>
@@ -75,16 +75,11 @@
             component.executeMapping(true)">Map document
                 </button>
             </div>
-            <script type="module">
-                import { ajaxBaseUrl, keycloak, tags, showServiceUrl, appDescription } from './js/mapping-service.settings.js';
-                applyConfig(ajaxBaseUrl, keycloak, tags, showServiceUrl, appDescription)
-            </script>
         </div>
-  </div>
     <script type="module">
         import { keycloak, showServiceUrl } from './settings/general.settings.js';
         import { ajaxBaseUrl, appDescription } from './settings/mapping-service.settings.js';
-        document.getElementById("input-component").setAttribute("base-url", ajaxBaseUrl);
+        setUrl(ajaxBaseUrl);
         applyConfig(keycloak, showServiceUrl, appDescription)
     </script>
 </body>


### PR DESCRIPTION
**This PR addresses the following bugs:**

- [x]  setting `showServiceURL` to `true` is overwritten by faulty and obsolete applyConfig call (where serviceURL is always undefined).
- [x] setting the `ajaxBaseURL` via settings file is not reflected in the service URL input field. The input field always shows the hard-coded base-url "http://localhost:8095/" instead.

**This PR contains the following improvements:**
- [x] URL setting is now always done via `setURL()` function instead of directly via DOM element. Not sure if this is the most elegant solution, feel free to change.

**This PR does NOT address the following bugs:**
- [ ] Reload of the service input URL only results in changes of the plugins if the backend call is successful. Otherwise the plugin list stays the same but the rest of the page stops working properly. I assume this may be an issue in the com_mapping-service-input module rather than the frontend.